### PR TITLE
enable pbe file loading

### DIFF
--- a/modules/core/src/loaders/xviz-file-loader.js
+++ b/modules/core/src/loaders/xviz-file-loader.js
@@ -108,6 +108,7 @@ export default class XVIZFileLoader extends XVIZLoaderInterface {
     let file;
     switch (fileFormat) {
       case 'glb':
+      case 'pbe':
         file = fetch(filePath).then(resp => resp.arrayBuffer());
         break;
 


### PR DESCRIPTION
The switch case prevented protobuf files from loading.

Adding a pbe case allows them to load.